### PR TITLE
Fixed wasm file name of the build target.

### DIFF
--- a/contract/build.bat
+++ b/contract/build.bat
@@ -1,2 +1,2 @@
 cargo build --target wasm32-unknown-unknown --release
-copy target\wasm32-unknown-unknown\release\rust_template.wasm res
+copy target\wasm32-unknown-unknown\release\crossword_tutorial_chapter_1.wasm res

--- a/contract/build.sh
+++ b/contract/build.sh
@@ -2,5 +2,5 @@
 set -e
 
 RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
-cp target/wasm32-unknown-unknown/release/rust_template.wasm ./res/
+cp target/wasm32-unknown-unknown/release/crossword_tutorial_chapter_1.wasm ./res/
 


### PR DESCRIPTION
Issue:
Attempted to build with ```./build.sh``` but the .wasm file was not copied over to ```/res```

Solution was to simply replace the template file name in the two scripts.